### PR TITLE
Added proxy function getAutoRejectMode for fix problems with some ims

### DIFF
--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -636,6 +636,10 @@ public class QtiImsExtUtils {
                 QtiCallConstants.IMS_AUTO_REJECT + phoneId,
                 QtiCallConstants.AUTO_REJECT_CALL_DISABLED);
     }
+    // Make proxy function for working with some ims.apk 
+    public static int getAutoRejectMode(ContentResolver contentResolver, int phoneId) {
+      return getAutoReject(contentResolver, phoneId);
+    }
 
     public static boolean canAcceptAsOneWayVideo(int phoneId, Context context) {
         return (isCarrierConfigEnabled(phoneId, context,


### PR DESCRIPTION
Fix error ims service:
in some older versions of ims 

/AndroidRuntime(24028): java.lang.NoSuchMethodError: No static method getAutoRejectMode(Landroid/content/ContentResolver;I)I in class Lorg/codeaurora/ims/utils/QtiImsExtUtils; or its super classes (declaration of 'org.codeaurora.ims.utils.QtiImsExtUtils' appears in /system/framework/ims-ext-common_system.jar)

added proxy function